### PR TITLE
Version 3.0.43

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_branch: 3.12

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,3 @@
 aggregate_branch: 3.12
+
+staging_channel_upload_target: ipython_8.19.0

--- a/recipe/build_base.bat
+++ b/recipe/build_base.bat
@@ -1,1 +1,1 @@
-%PYTHON% -m pip install . --no-deps -vv
+%PYTHON% -m pip install . --no-deps -vv --no-build-isolation

--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -1,1 +1,1 @@
-${PYTHON} -m pip install . --no-deps -vv
+${PYTHON} -m pip install . --no-deps -vv --no-build-isolation

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "prompt-toolkit" %}
-{% set version = "3.0.36" %}
+{% set version = "3.0.43" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/prompt_toolkit/prompt_toolkit-{{ version }}.tar.gz
-  sha256: 3e163f254bef5a03b146397d7c1963bd3e2812f0964bb9a24e6ec761fd28db63
+  sha256: 3527b7af26106cbc65a040bcc84839a3566ec1b051bb0bfe953631e704b0ff7d
 
 build:
   number: 0


### PR DESCRIPTION
prompt_toolkit 3.0.43

**Destination channel:** defaults

### Links

- [PKG-3733](https://anaconda.atlassian.net/browse/PKG-3733)
- [Upstream repository](https://github.com/prompt-toolkit/python-prompt-toolkit/tree/3.0.43)
- [Upstream changelog/diff](https://github.com/prompt-toolkit/python-prompt-toolkit/blob/3.0.43/CHANGELOG)

### Explanation of changes:

- Bump version to `3.0.43`
- Update `build.sh` and `build.bat` to include `--no-build-isolation`


[PKG-3733]: https://anaconda.atlassian.net/browse/PKG-3733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ